### PR TITLE
games-roguelike/stone-soup: Build depends on dev-python/pyyaml

### DIFF
--- a/games-roguelike/stone-soup/stone-soup-0.23.0.ebuild
+++ b/games-roguelike/stone-soup/stone-soup-0.23.0.ebuild
@@ -46,6 +46,7 @@ RDEPEND="
 	)"
 DEPEND="${RDEPEND}
 	dev-lang/perl
+	dev-python/pyyaml
 	sys-devel/flex
 	virtual/pkgconfig
 	virtual/yacc


### PR DESCRIPTION
If `games-roguelike/stone-soup-0.23.0` is built without `dev-python/pyyaml` installed, `util/species-gen.py` fails to run, giving an `ImportError`.

This appears to be new with `0.23`. `0.22` builds fine without `pyyaml`.

```
util/species-gen.py dat/species/ util/species-gen/ species-data.h aptitudes.h species-groups.h species-type.h
Traceback (most recent call last):
  File "util/species-gen.py", line 12, in <module>
    import yaml  # pip install pyyaml
ImportError: No module named yaml
make: *** [Makefile:1622: species-data.h] Error 1
 * ERROR: games-roguelike/stone-soup-0.23.0::gentoo failed (compile phase):
 *   emake failed
```